### PR TITLE
Fix GLIBC compatibility in RHTAP Dockerfiles

### DIFF
--- a/build/Dockerfile.addon.rhtap
+++ b/build/Dockerfile.addon.rhtap
@@ -3,7 +3,7 @@ WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
 
-RUN GO_BUILD_PACKAGES=./cmd/addon make build --warn-undefined-variables
+RUN CGO_ENABLED=0 GO_BUILD_PACKAGES=./cmd/addon make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/build/Dockerfile.placement.rhtap
+++ b/build/Dockerfile.placement.rhtap
@@ -3,7 +3,7 @@ WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
 
-RUN GO_BUILD_PACKAGES=./cmd/placement make build --warn-undefined-variables
+RUN CGO_ENABLED=0 GO_BUILD_PACKAGES=./cmd/placement make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/build/Dockerfile.registration-operator.rhtap
+++ b/build/Dockerfile.registration-operator.rhtap
@@ -8,7 +8,7 @@ ARG MCE_VERSION_2_11
 ENV SOURCE_GIT_TAG=${MCE_VERSION_2_11}
 RUN echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}"
 
-RUN GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables
+RUN CGO_ENABLED=0 GO_BUILD_PACKAGES=./cmd/registration-operator make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/build/Dockerfile.registration.rhtap
+++ b/build/Dockerfile.registration.rhtap
@@ -3,7 +3,7 @@ WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
 
-RUN GO_BUILD_PACKAGES=./cmd/registration make build --warn-undefined-variables
+RUN CGO_ENABLED=0 GO_BUILD_PACKAGES=./cmd/registration make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/build/Dockerfile.work.rhtap
+++ b/build/Dockerfile.work.rhtap
@@ -3,7 +3,7 @@ WORKDIR /go/src/open-cluster-management.io/ocm
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/ocm
 
-RUN GO_BUILD_PACKAGES=./cmd/work make build --warn-undefined-variables
+RUN CGO_ENABLED=0 GO_BUILD_PACKAGES=./cmd/work make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
## Summary
Fix GLIBC version compatibility issue in RHTAP Dockerfiles by adding `CGO_ENABLED=0` to create statically linked binaries.

## Problem
The golang:1.25-bookworm builder image uses GLIBC 2.36, while the UBI9 minimal runtime image only has GLIBC 2.34. When running binaries built with CGO enabled, they fail with:
```
/lib64/libc.so.6: version 'GLIBC_2.32' not found
/lib64/libc.so.6: version 'GLIBC_2.34' not found
```

## Solution
Added `CGO_ENABLED=0` to all RHTAP Dockerfile build steps to create pure Go static binaries that don't depend on GLIBC at runtime.

## Changes
- ✅ `build/Dockerfile.addon.rhtap` - Added `CGO_ENABLED=0`
- ✅ `build/Dockerfile.placement.rhtap` - Added `CGO_ENABLED=0`
- ✅ `build/Dockerfile.registration-operator.rhtap` - Added `CGO_ENABLED=0`
- ✅ `build/Dockerfile.registration.rhtap` - Added `CGO_ENABLED=0`
- ✅ `build/Dockerfile.work.rhtap` - Added `CGO_ENABLED=0`

## Benefits
- ✅ Binaries run successfully on UBI9 minimal without GLIBC version conflicts
- ✅ More portable and distribution-agnostic
- ✅ No dynamic library dependencies
- ✅ Smaller attack surface

## Test Plan
- [ ] Build RHTAP images with the changes
- [ ] Run containers and verify binaries execute without GLIBC errors
- [ ] Verify all operators start successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)