### PR TITLE
feat(addon): optimize ClusterManagementAddOn status message format

### DIFF
--- a/pkg/addon/controllers/addonconfiguration/cma_progressing_reconciler_test.go
+++ b/pkg/addon/controllers/addonconfiguration/cma_progressing_reconciler_test.go
@@ -95,7 +95,7 @@ func TestMgmtAddonProgressingReconcile(t *testing.T) {
 				if cma.Status.InstallProgressions[0].Conditions[0].Reason != addonv1alpha1.ProgressingReasonProgressing {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions[0].Reason)
 				}
-				if cma.Status.InstallProgressions[0].Conditions[0].Message != "0/2 progressing..., 0 failed 0 timeout." {
+				if cma.Status.InstallProgressions[0].Conditions[0].Message != "Clusters: 2 selected, 0 effective. Status: 0 progressing, 0 completed, 0 failed, 0 timeout." {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions[0].Message)
 				}
 			},
@@ -202,7 +202,7 @@ func TestMgmtAddonProgressingReconcile(t *testing.T) {
 				if cma.Status.InstallProgressions[0].Conditions[0].Reason != addonv1alpha1.ProgressingReasonProgressing {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions[0].Reason)
 				}
-				if cma.Status.InstallProgressions[0].Conditions[0].Message != "1/2 progressing..., 0 failed 0 timeout." {
+				if cma.Status.InstallProgressions[0].Conditions[0].Message != "Clusters: 2 selected, 1 effective. Status: 1 progressing, 0 completed, 0 failed, 0 timeout." {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions[0].Message)
 				}
 			},
@@ -303,7 +303,7 @@ func TestMgmtAddonProgressingReconcile(t *testing.T) {
 				if cma.Status.InstallProgressions[0].Conditions[0].Reason != addonv1alpha1.ProgressingReasonCompleted {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions)
 				}
-				if cma.Status.InstallProgressions[0].Conditions[0].Message != "1/1 completed with no errors, 0 failed 0 timeout." {
+				if cma.Status.InstallProgressions[0].Conditions[0].Message != "Clusters: 1 selected, 1 effective. Status: 1 completed, 0 failed, 0 timeout." {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions)
 				}
 			},
@@ -397,7 +397,7 @@ func TestMgmtAddonProgressingReconcile(t *testing.T) {
 				if cma.Status.InstallProgressions[0].Conditions[0].Reason != addonv1alpha1.ProgressingReasonProgressing {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions)
 				}
-				if cma.Status.InstallProgressions[0].Conditions[0].Message != "1/2 progressing..., 0 failed 0 timeout." {
+				if cma.Status.InstallProgressions[0].Conditions[0].Message != "Clusters: 2 selected, 1 effective. Status: 1 progressing, 0 completed, 0 failed, 0 timeout." {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions)
 				}
 			},
@@ -506,7 +506,7 @@ func TestMgmtAddonProgressingReconcile(t *testing.T) {
 				if cma.Status.InstallProgressions[0].Conditions[0].Reason != addonv1alpha1.ProgressingReasonCompleted {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions)
 				}
-				if cma.Status.InstallProgressions[0].Conditions[0].Message != "1/1 completed with no errors, 0 failed 0 timeout." {
+				if cma.Status.InstallProgressions[0].Conditions[0].Message != "Clusters: 1 selected, 1 effective. Status: 1 completed, 0 failed, 0 timeout." {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions)
 				}
 			},
@@ -592,7 +592,7 @@ func TestMgmtAddonProgressingReconcile(t *testing.T) {
 				if cma.Status.InstallProgressions[0].Conditions[0].Reason != addonv1alpha1.ProgressingReasonProgressing {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions)
 				}
-				if cma.Status.InstallProgressions[0].Conditions[0].Message != "0/1 progressing..., 0 failed 0 timeout." {
+				if cma.Status.InstallProgressions[0].Conditions[0].Message != "Clusters: 1 selected, 1 effective. Status: 0 progressing, 0 completed, 0 failed, 0 timeout." {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions)
 				}
 			},
@@ -667,7 +667,7 @@ func TestMgmtAddonProgressingReconcile(t *testing.T) {
 				if cma.Status.InstallProgressions[0].Conditions[0].Reason != addonv1alpha1.ProgressingReasonProgressing {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions)
 				}
-				if cma.Status.InstallProgressions[0].Conditions[0].Message != "1/2 progressing..., 0 failed 0 timeout." {
+				if cma.Status.InstallProgressions[0].Conditions[0].Message != "Clusters: 2 selected, 1 effective. Status: 1 progressing, 0 completed, 0 failed, 0 timeout." {
 					t.Errorf("InstallProgressions condition is not correct: %v", cma.Status.InstallProgressions[0].Conditions[0].Message)
 				}
 			},


### PR DESCRIPTION
This commit improves the status message in installProgressions to provide clearer visibility into cluster management state, especially in overlapping placement scenarios.

Key changes:
- Add 'effective' parameter to track actual managed clusters (len(children))
- Distinguish between 'selected' (from PlacementDecision) and 'effective' (actually managed) cluster counts
- Display detailed status breakdown: progressing, completed, failed, timeout
- Use 'effective' count for completion logic instead of 'total'

Example message format:
Before: "1/2 progressing..., 0 failed 0 timeout."
After:  "Clusters: 2 selected, 1 effective. Status: 1 progressing, 0 completed, 0 failed, 0 timeout."

This resolves confusion when multiple placements select the same cluster, where higher priority placements "take over" clusters from lower priority ones.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #