### PR TITLE
fix: add nil checks for ConfigReference.DesiredConfig

### DIFF
--- a/pkg/addon/controllers/addonconfiguration/addon_configuration_reconciler.go
+++ b/pkg/addon/controllers/addonconfiguration/addon_configuration_reconciler.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
@@ -95,6 +96,15 @@ func (d *managedClusterAddonConfigurationReconciler) mergeAddonConfig(
 		if _, ok := mergedConfigs[gr]; !ok {
 			mergedConfigs[gr] = []addonv1alpha1.ConfigReference{}
 		}
+
+		// skip config references without desired config
+		if configRef.DesiredConfig == nil {
+			klog.Warningf("ManagedClusterAddon %s/%s has configReference without desiredConfig, "+
+				"skipping during merge",
+				mca.Namespace, mca.Name)
+			continue
+		}
+
 		if _, ok := desiredConfigMap.containsConfig(gr, configRef.DesiredConfig.ConfigReferent); ok {
 			mergedConfigs[gr] = append(mergedConfigs[gr], configRef)
 		}

--- a/pkg/addon/controllers/addonconfiguration/graph.go
+++ b/pkg/addon/controllers/addonconfiguration/graph.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterlisterv1beta1 "open-cluster-management.io/api/client/cluster/listers/cluster/v1beta1"
@@ -69,6 +70,18 @@ func (n *addonNode) setRolloutStatus() {
 	}
 
 	for _, actual := range n.mca.Status.ConfigReferences {
+		// skip config references without desired config
+		if actual.DesiredConfig == nil {
+			klog.Warningf("ManagedClusterAddon %s/%s has configReference without desiredConfig, "+
+				"marking as ToApply to trigger configuration initialization",
+				n.mca.Namespace, n.mca.Name)
+			n.status = &clustersdkv1alpha1.ClusterRolloutStatus{
+				ClusterName: n.mca.Namespace,
+				Status:      clustersdkv1alpha1.ToApply,
+			}
+			return
+		}
+
 		if index, exist := n.desiredConfigs.containsConfig(actual.ConfigGroupResource, actual.DesiredConfig.ConfigReferent); exist {
 			// desired config spec hash doesn't match actual, set to ToApply
 			if !equality.Semantic.DeepEqual(n.desiredConfigs[actual.ConfigGroupResource][index].DesiredConfig, actual.DesiredConfig) {

--- a/pkg/addon/controllers/addonprogressing/controller.go
+++ b/pkg/addon/controllers/addonprogressing/controller.go
@@ -301,7 +301,10 @@ func setAddOnProgressingAndLastApplied(reason string, message string, addon *add
 	case addonapiv1alpha1.ProgressingReasonCompleted:
 		condition.Status = metav1.ConditionFalse
 		for i, configReference := range addon.Status.ConfigReferences {
-			addon.Status.ConfigReferences[i].LastAppliedConfig = configReference.DesiredConfig.DeepCopy()
+			// skip config references without desired config
+			if configReference.DesiredConfig != nil {
+				addon.Status.ConfigReferences[i].LastAppliedConfig = configReference.DesiredConfig.DeepCopy()
+			}
 		}
 		condition.Message = "completed with no errors."
 	case addonapiv1alpha1.ProgressingReasonFailed:


### PR DESCRIPTION
This commit fixes three nil pointer dereference bugs when processing ManagedClusterAddon objects with incomplete ConfigReferences status.

The DesiredConfig field in ConfigReference is optional and can be nil. Some ManagedClusterAddon objects (like hypershift-addon) had ConfigReferences with nil DesiredConfig, causing panics in:

1. pkg/addon/controllers/addonconfiguration/graph.go:72
   - setRolloutStatus() method
   - Now marks addon as ToApply to trigger initialization

2. pkg/addon/controllers/addonconfiguration/addon_configuration_reconciler.go:98
   - mergeAddonConfig() method
   - Now skips nil entries during merge

3. pkg/addon/controllers/addonprogressing/controller.go:304
   - setAddOnProgressingAndLastApplied() method
   - Now only copies when DesiredConfig is not nil

This fix aligns with the defensive programming pattern already used elsewhere in the codebase (graph.go:180, 375, 580) and in addon-framework's addonconfig controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #